### PR TITLE
Fix code scanning alert no. 86: Server-side request forgery

### DIFF
--- a/src/main/java/org/joychou/controller/SSRF.java
+++ b/src/main/java/org/joychou/controller/SSRF.java
@@ -1,4 +1,6 @@
 package org.joychou.controller;
+import java.util.Arrays;
+import java.util.List;
 
 import cn.hutool.http.HttpUtil;
 import org.joychou.security.SecurityUtil;

--- a/src/main/java/org/joychou/util/HttpUtils.java
+++ b/src/main/java/org/joychou/util/HttpUtils.java
@@ -32,6 +32,19 @@ import java.util.concurrent.*;
  * @author JoyChou 2020-04-06
  */
 public class HttpUtils {
+    private static final List<String> ALLOWED_URLS = Arrays.asList(
+        "http://example.com",
+        "http://another-allowed-url.com"
+    );
+
+    private static boolean isValidUrl(String url) {
+        try {
+            URI uri = new URI(url);
+            return ALLOWED_URLS.contains(uri.getScheme() + "://" + uri.getHost());
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
 
     private final static Logger logger = LoggerFactory.getLogger(HttpUtils.class);
 
@@ -203,6 +216,9 @@ public class HttpUtils {
 
 
     public static String HttpAsyncClients(String url) {
+        if (!isValidUrl(url)) {
+            return "Invalid URL";
+        }
         CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
         try {
             httpclient.start();


### PR DESCRIPTION
Fixes [https://github.com/wangwangping/java-sec-code/security/code-scanning/86](https://github.com/wangwangping/java-sec-code/security/code-scanning/86)

To fix the SSRF vulnerability, we need to validate the user-provided URL to ensure it is safe. One way to do this is to maintain a whitelist of allowed URLs or domains and check the user input against this list. Alternatively, we can restrict the URLs to a specific host or URL prefix.

In this case, we will implement a whitelist approach. We will create a method to validate the URL against a predefined list of allowed URLs or domains. If the URL is not in the whitelist, we will reject the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
